### PR TITLE
Add a docker compose setup to run site locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.7-slim-bullseye
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    ruby2.7-dev
+
+RUN mkdir /iris-project
+COPY Gemfile /iris-project/Gemfile
+COPY Gemfile.lock /iris-project/Gemfile.lock
+WORKDIR /iris-project
+RUN gem install bundler:2.4.6
+RUN bundle config set --local path '.bundle'
+RUN bundle install
+
+CMD bundle exec jekyll serve --watch --host 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ You should then be able to run the following command to have Jekyll serve the si
 bundle exec jekyll serve
 ```
 
+Alternately, you can use Docker (and Docker Compose). Run `docker-compose up
+--build` to build and run the container, then navigate to `localhost:4000`.
+
 ## How to add publications
 
 To add a new publication simply edit `_data/publications.json`, find

--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,5 @@ exclude:
   - README.md
   - iris-logo
   - Makefile
+  - Dockerfile
+  - docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  server:
+    image: iris-project:latest
+    build:
+      dockerfile: Dockerfile
+      context: .
+    ports:
+      - 4000:4000
+    volumes:
+      - ./:/iris-project


### PR DESCRIPTION
Using Docker avoids the need to have a working Ruby installation at all, let alone the right versions of Ruby and bundler.

This setup also uses docker compose to make launching the container simple. Without it, you would need to run

```sh
docker build -t iris-project .
docker run -it --rm -p 4000:4000 -v "$PWD:/iris-project" iris-project
```