### PR TITLE
Correct a dead link

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
               of exercises to practice the Iris tactics in Coq. A <a
                 href="https://www.youtube.com/watch?v=LjXaffBpMag">video recording</a> of the tutorial talk is also
               available.</li>
-            <li>The paper <a href="pdfs/2024-submitted-logical-type-soundness.pdf">A Logical Approach to Type
+            <li>The paper <a href="pdfs/2024-jacm-logical-type-soundness.pdf">A Logical Approach to Type
                 Soundness</a>
               shows how Iris can be used to prove type soundness. See also the <a
                 href="https://www.youtube.com/watch?v=8Xyk_dGcAwk">video recording</a> of Derek Dreyer's POPL'18 keynote


### PR DESCRIPTION
This corrects a link to "A Logical Approach to Type Soundness" that was not updated after acceptance