### PR TITLE
Fix CSS to properly display publications with small browser witdth

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,26 @@
 dl.ref {
-  counter-reset: pub-counter-1 pub-counter-2;
+  counter-reset: pub-counter-1;
   padding-left: 50px;
   padding-top: 15px;
+  width: 100%;
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  & dt {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 /3;
+  }
+  & dt:before {
+    grid-column: 1;
+    content: "[" counter(pub-counter-1) "] ";
+    counter-increment: pub-counter-1;
+    margin-right: 0.5em;
+  }
+  & dd {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 2/3;
+  }
 }
 
 dl.ref > dt:before {


### PR DESCRIPTION
If the browser width is too small, the publication list is not displayed properly:

![image](https://github.com/user-attachments/assets/ac9c3198-901a-42f5-966d-96e83c6f46e1)

This PR contains a fix by @janno.

Since I have no idea about CSS I have no idea what this doing...
