### PR TITLE
Fix displaying of publications with small browser width

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,27 +1,28 @@
 dl.ref {
-  counter-reset: pub-counter-1 pub-counter-2;
+  counter-reset: pub-counter-1;
   padding-left: 50px;
   padding-top: 15px;
-}
+  width: 100%;
+  display: grid;
+  grid-template-columns: min-content 1fr;
 
-dl.ref > dt:before {
-  content: "[" counter(pub-counter-1) "] ";
-  counter-increment: pub-counter-1;
-  position: relative;
-  left: -10px;
-}
-
-dl.ref > dd:before {
-  content: "[" counter(pub-counter-2) "] ";
-  counter-increment: pub-counter-2;
-  position: relative;
-  left: -10px;
-  font-weight: bold;
-  visibility: hidden;
-}
-
-dl.ref > dd {
-  margin-bottom: 20px;
+  & dt {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 /3;
+  }
+  & dt:before {
+    grid-column: 1;
+    content: "[" counter(pub-counter-1) "] ";
+    counter-increment: pub-counter-1;
+    margin-right: 0.5em;
+  }
+  & dd {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 2/3;
+    margin-bottom: 20px;
+  }
 }
 
 div.entry {


### PR DESCRIPTION
This is a fixed version of #51. I wasn't very clear on mattermost with how to apply the change so the first PR ended up not replacing all the existing styles.

The new style is very similar except that it increases the gap between the number and the title to accommodate all digits. This fixes a mis-alignment issue when the number of digits changes: 
<img width="481" alt="image" src="https://github.com/user-attachments/assets/a31f2846-f42e-4cc4-a3f8-71b1e5ccc0f7" />

Now the title and buttons are aligned: 
<img width="477" alt="image" src="https://github.com/user-attachments/assets/8fe3314a-8a6a-46ba-93b3-e83f1fbf3de1" />


Bigger screenshots of the start of the list:

before: 
<img width="458" alt="before" src="https://github.com/user-attachments/assets/725972de-68d5-4130-ae10-ce58e7bccfb9" />

after:
<img width="473" alt="after" src="https://github.com/user-attachments/assets/cacc02d1-fc7e-4968-984f-66768cc67019" />

/cc @robbertkrebbers  @RalfJung