### PR TITLE
Make the publication display more compact.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 dl.ref {
   counter-reset: pub-counter-1;
   padding-left: 10px;
-  padding-top: 0px;
+  padding-top: 7px;
   width: 100%;
   display: grid;
   grid-template-columns: min-content 1fr;

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 dl.ref {
   counter-reset: pub-counter-1;
-  padding-left: 50px;
-  padding-top: 15px;
+  padding-left: 10px;
+  padding-top: 0px;
   width: 100%;
   display: grid;
   grid-template-columns: min-content 1fr;
@@ -15,13 +15,13 @@ dl.ref {
     grid-column: 1;
     content: "[" counter(pub-counter-1) "] ";
     counter-increment: pub-counter-1;
-    margin-right: 0.5em;
+    margin-right: 2px;
   }
   & dd {
     display: grid;
     grid-template-columns: subgrid;
     grid-column: 2/3;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
   }
 }
 


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/019a721f-8b27-49bb-a8c7-d379f02fcc6f)

After:

![image](https://github.com/user-attachments/assets/c7489b47-3863-40a5-b6fe-8bcc8c2c1a5f)

Especially on a phone, all the spacing is IMHO quite a waste.

PS: Thanks to @Janno for fixing the prior issues!